### PR TITLE
Download tool rework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ magicmemoryview
 
 # Downloader
 sh
+
+# Command-line option parsing
+docopt

--- a/ruaumoko/_compat.py
+++ b/ruaumoko/_compat.py
@@ -1,0 +1,114 @@
+# Copyright 2014 (C) Rich Wareham
+#
+# This file is part of Ruaumoko.
+# https://github.com/cuspaceflight/ruaumoko
+#
+# Ruaumoko is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ruaumoko is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ruaumoko. If not, see <http://www.gnu.org/licenses/>.
+"""Compatibility utilities.
+
+Python 2/3 compatibility shims.
+"""
+from __future__ import print_function
+
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    # Taken from:
+    # http://stackoverflow.com/questions/19296146/with-tempfile-temporarydirectory
+    import warnings as _warnings
+    import os as _os
+
+    from tempfile import mkdtemp
+
+    class TemporaryDirectory(object):
+        """Create and return a temporary directory.  This has the same
+        behavior as mkdtemp but can be used as a context manager.  For
+        example:
+
+            with TemporaryDirectory() as tmpdir:
+                ...
+
+        Upon exiting the context, the directory and everything contained
+        in it are removed.
+        """
+
+        def __init__(self, suffix="", prefix="tmp", dir=None):
+            self._closed = False
+            self.name = None # Handle mkdtemp raising an exception
+            self.name = mkdtemp(suffix, prefix, dir)
+
+        def __repr__(self):
+            return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+        def __enter__(self):
+            return self.name
+
+        def cleanup(self, _warn=False):
+            if self.name and not self._closed:
+                try:
+                    self._rmtree(self.name)
+                except (TypeError, AttributeError) as ex:
+                    # Issue #10188: Emit a warning on stderr
+                    # if the directory could not be cleaned
+                    # up due to missing globals
+                    if "None" not in str(ex):
+                        raise
+                    print("ERROR: {!r} while cleaning up {!r}".format(ex, self,),
+                          file=_sys.stderr)
+                    return
+                self._closed = True
+                if _warn:
+                    self._warn("Implicitly cleaning up {!r}".format(self),
+                               ResourceWarning)
+
+        def __exit__(self, exc, value, tb):
+            self.cleanup()
+
+        def __del__(self):
+            # Issue a ResourceWarning if implicit cleanup needed
+            self.cleanup(_warn=True)
+
+        # XXX (ncoghlan): The following code attempts to make
+        # this class tolerant of the module nulling out process
+        # that happens during CPython interpreter shutdown
+        # Alas, it doesn't actually manage it. See issue #10188
+        _listdir = staticmethod(_os.listdir)
+        _path_join = staticmethod(_os.path.join)
+        _isdir = staticmethod(_os.path.isdir)
+        _islink = staticmethod(_os.path.islink)
+        _remove = staticmethod(_os.remove)
+        _rmdir = staticmethod(_os.rmdir)
+        _warn = _warnings.warn
+
+        def _rmtree(self, path):
+            # Essentially a stripped down version of shutil.rmtree.  We can't
+            # use globals because they may be None'ed out at shutdown.
+            for name in self._listdir(path):
+                fullname = self._path_join(path, name)
+                try:
+                    isdir = self._isdir(fullname) and not self._islink(fullname)
+                except OSError:
+                    isdir = False
+                if isdir:
+                    self._rmtree(fullname)
+                else:
+                    try:
+                        self._remove(fullname)
+                    except OSError:
+                        pass
+            try:
+                self._rmdir(path)
+            except OSError:
+                pass
+

--- a/ruaumoko/_compat.py
+++ b/ruaumoko/_compat.py
@@ -22,6 +22,11 @@ Python 2/3 compatibility shims.
 from __future__ import print_function
 
 try:
+    from urllib.parse import urlunsplit # py 3
+except ImportError:
+    from urlparse import urlunsplit # py 2
+
+try:
     from tempfile import TemporaryDirectory
 except ImportError:
     # Taken from:

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -62,11 +62,9 @@ import zipfile
 
 from docopt import docopt
 from sh import wget, convert, unzip
-from six import iteritems
-from six.moves.urllib.parse import urlunsplit
 
 from . import Dataset
-from ._compat import TemporaryDirectory
+from ._compat import TemporaryDirectory, urlunsplit
 
 # HACK: interpolate dataset default location into docopt string.
 __doc__ = __doc__.format(

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -21,7 +21,6 @@ Download Digital Elevation Map (DEM) data for the Ruaumoko server.
 Usage:
     ruaumoko-download (-h | --help)
     ruaumoko-download [(-v | --verbose)] [--host HOSTNAME] [--path PATH]
-        [--tiff-file-pattern PATTERN] [--zip-file-pattern PATTERN]
         [--chunks CHUNKS] [<dataset-location>]
 
 Options:
@@ -36,14 +35,8 @@ Advanced options:
                                     [default: www.viewfinderpanoramas.org]
     --path PATH                     Path to DEM TIF files on server.
                                     [default: DEM/TIF15]
-    --zip-file-pattern PATTERN      Pattern for zip file to fetch from server.
-                                    [default: 15-<CHUNK>.zip]
-    --tiff-file-pattern PATTERN     Pattern for TIFF file within zip file.
-                                    [default: 15-<CHUNK>.tif]
     --chunks CHUNKS                 Download only specific chunks from the
                                     server. See below.
-
-    Filename patterns will have <CHUNK> replaced with the current chunk.
 
     Specific chunks are specified as a comma-separated list of chunk ids. For
     example, the option "--chunks A,G,H" will fetch only chunks A, G and H from
@@ -74,6 +67,10 @@ __doc__ = __doc__.format(
 # Logger for the main utility
 LOG = logging.getLogger(os.path.basename(sys.argv[0]))
 
+# Filename patterns
+TIFF_PATTERN = '15-<CHUNK>.tif'
+ZIP_PATTERN = '15-<CHUNK>.zip'
+
 EXPECT_SIZE = 14401 * 10801 * 2
 
 def char_range(frm, to):
@@ -89,7 +86,8 @@ def expand_pattern(pattern, **kwargs):
         pattern = pattern.replace('<'+k+'>', v)
     return pattern
 
-def download(target, temp_dir, host, path, zip_pattern, tiff_pattern, chunks=None):
+def download(target, temp_dir, host, path,
+        zip_pattern=ZIP_PATTERN, tiff_pattern=TIFF_PATTERN, chunks=None):
     zip_path = os.path.join(temp_dir, "temp.zip")
     tgt_path = os.path.join(temp_dir, "chunk")
 
@@ -141,8 +139,6 @@ def main():
             download(
                 target_f, temp_dir,
                 host = opts['--host'], path = opts['--path'],
-                tiff_pattern = opts['--tiff-file-pattern'],
-                zip_pattern = opts['--zip-file-pattern'],
                 chunks = opts['--chunks'],
             )
 

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -20,8 +20,8 @@ Download Digital Elevation Map (DEM) data for the Ruaumoko server.
 
 Usage:
     ruaumoko-download (-h | --help)
-    ruaumoko-download [(-v | --verbose)] [--host HOSTNAME] [--path PATH]
-        [--chunks CHUNKS] [<dataset-location>]
+    ruaumoko-download [(-v | --verbose)] [--host HOSTNAME] [--chunks CHUNKS]
+        [<dataset-location>]
 
 Options:
     -h, --help                      Print a brief usage summary.
@@ -33,8 +33,6 @@ Options:
 Advanced options:
     --host HOSTNAME                 Host name of DEM server.
                                     [default: www.viewfinderpanoramas.org]
-    --path PATH                     Path to DEM TIF files on server.
-                                    [default: DEM/TIF15]
     --chunks CHUNKS                 Download only specific chunks from the
                                     server. See below.
 
@@ -70,6 +68,7 @@ LOG = logging.getLogger(os.path.basename(sys.argv[0]))
 # Filename patterns
 TIFF_PATTERN = '15-<CHUNK>.tif'
 ZIP_PATTERN = '15-<CHUNK>.zip'
+DEM_PATH = 'DEM/TIF15'
 
 EXPECT_SIZE = 14401 * 10801 * 2
 
@@ -86,7 +85,7 @@ def expand_pattern(pattern, **kwargs):
         pattern = pattern.replace('<'+k+'>', v)
     return pattern
 
-def download(target, temp_dir, host, path,
+def download(target, temp_dir, host, path=DEM_PATH,
         zip_pattern=ZIP_PATTERN, tiff_pattern=TIFF_PATTERN, chunks=None):
     zip_path = os.path.join(temp_dir, "temp.zip")
     tgt_path = os.path.join(temp_dir, "chunk")
@@ -138,7 +137,7 @@ def main():
         with TemporaryDirectory() as temp_dir:
             download(
                 target_f, temp_dir,
-                host = opts['--host'], path = opts['--path'],
+                host = opts['--host'],
                 chunks = opts['--chunks'],
             )
 

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -15,6 +15,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ruaumoko. If not, see <http://www.gnu.org/licenses/>.
+"""
+Download Digital Elevation Map (DEM) data for the Ruaumoko server.
+
+Usage:
+    ruaumoko-download (-h | --help)
+    ruaumoko-download [options] [<dataset-location>]
+
+Options:
+    -h, --help          Print a brief usage summary.
+
+    <dataset-location>  Location to store DEM dataset.
+                        [default: {default_location}]
+
+"""
 
 from __future__ import print_function
 
@@ -26,9 +40,15 @@ import zipfile
 
 from os import path
 
+from docopt import docopt
 from sh import wget, convert, unzip
 
 from . import Dataset
+
+# HACK: interpolate dataset default location into docopt string.
+__doc__ = __doc__.format(
+    default_location = Dataset.default_location,
+)
 
 URL_FORMAT = "http://www.viewfinderpanoramas.org/DEM/TIF15/15-{}.zip"
 TIF_FORMAT = "15-{}.tif"
@@ -69,13 +89,8 @@ def download(target, temp_dir):
         os.unlink(tgt_path)
 
 def main():
-    if len(sys.argv) == 1:
-        target = Dataset.default_location
-    elif len(sys.argv) == 2:
-        target = sys.argv[1]
-    else:
-        print("Usage: {} [{}]".format(sys.argv[0], Dataset.default_location))
-        sys.exit(1)
+    opts = docopt(__doc__)
+    target = opts['<dataset-location>'] or Dataset.default_location
 
     with open(target, "wb") as target_f:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -60,6 +60,7 @@ from six import iteritems
 from six.moves.urllib.parse import urlunsplit
 
 from . import Dataset
+from ._compat import TemporaryDirectory
 
 # HACK: interpolate dataset default location into docopt string.
 __doc__ = __doc__.format(
@@ -128,7 +129,7 @@ def main():
     LOG.info('Downloading DEM to "{0}"'.format(target))
 
     with open(target, "wb") as target_f:
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             download(
                 target_f, temp_dir,
                 host = opts['--host'], path = opts['--path'],

--- a/ruaumoko/download.py
+++ b/ruaumoko/download.py
@@ -22,7 +22,7 @@ Usage:
     ruaumoko-download (-h | --help)
     ruaumoko-download [(-v | --verbose)] [--host HOSTNAME] [--path PATH]
         [--tiff-file-pattern PATTERN] [--zip-file-pattern PATTERN]
-        [<dataset-location>]
+        [--chunks CHUNKS] [<dataset-location>]
 
 Options:
     -h, --help                      Print a brief usage summary.
@@ -40,8 +40,14 @@ Advanced options:
                                     [default: 15-<CHUNK>.zip]
     --tiff-file-pattern PATTERN     Pattern for TIFF file within zip file.
                                     [default: 15-<CHUNK>.tif]
+    --chunks CHUNKS                 Download only specific chunks from the
+                                    server. See below.
 
     Filename patterns will have <CHUNK> replaced with the current chunk.
+
+    Specific chunks are specified as a comma-separated list of chunk ids. For
+    example, the option "--chunks A,G,H" will fetch only chunks A, G and H from
+    the server.
 
 """
 
@@ -76,6 +82,7 @@ def char_range(frm, to):
     # inclusive endpoints
     return map(chr, range(ord(frm), ord(to) + 1))
 
+# Default set of chunks to download
 CHUNKS = list(char_range('A', 'X'))
 
 def expand_pattern(pattern, **kwargs):
@@ -84,12 +91,15 @@ def expand_pattern(pattern, **kwargs):
         pattern = pattern.replace('<'+k+'>', v)
     return pattern
 
-def download(target, temp_dir, host, path, zip_pattern, tiff_pattern):
+def download(target, temp_dir, host, path, zip_pattern, tiff_pattern, chunks=None):
     zip_path = os.path.join(temp_dir, "temp.zip")
     tgt_path = os.path.join(temp_dir, "chunk")
 
-    for chunk_idx, chunk in enumerate(CHUNKS):
-        LOG.info('Fetching chunk {0}/{1}'.format(chunk_idx+1, len(CHUNKS)))
+    chunks = chunks.split(',') if chunks is not None else CHUNKS
+    LOG.info('Fetching the following chunks: {0}'.format(','.join(chunks)))
+
+    for chunk_idx, chunk in enumerate(chunks):
+        LOG.info('Fetching chunk {0}/{1}'.format(chunk_idx+1, len(chunks)))
 
         tif_name = expand_pattern(tiff_pattern, CHUNK=chunk)
         tif_path = os.path.join(temp_dir, tif_name)
@@ -135,6 +145,7 @@ def main():
                 host = opts['--host'], path = opts['--path'],
                 tiff_pattern = opts['--tiff-file-pattern'],
                 zip_pattern = opts['--zip-file-pattern'],
+                chunks = opts['--chunks'],
             )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     description='Ground Elevation API',
     long_description=long_description,
     install_requires=[
+        "docopt",
         "Flask",
         "magicmemoryview",
         "sh"

--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,9 @@ def get_version():
 
 console_scripts = [
     "ruaumoko-api = ruaumoko.api:main",
-    "ruaumoko-get = ruaumoko.get_cmd:main"
+    "ruaumoko-get = ruaumoko.get_cmd:main",
+    "ruaumoko-download = ruaumoko.download:main",
 ]
-
-PY2 = sys.version_info[0] == 2
-if not PY2:
-    console_scripts.append("ruaumoko-download = ruaumoko.download:main")
 
 setup(
     name="Ruaumoko",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(
         "docopt",
         "Flask",
         "magicmemoryview",
-        "sh"
+        "sh",
+        "six"
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,7 @@ setup(
         "docopt",
         "Flask",
         "magicmemoryview",
-        "sh",
-        "six"
+        "sh"
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
I'm opening this PR mostly for discussion and sanity checking. I don't propose merging unless ACKed by someone more familiar with the predictor set up. (Such as @danielrichman.)

Give the download tool a little love and, in the process, port to Python 2. This is part of an effort to get a testing-friendly flavour of ruaumoko. There is currently no change to the (default) behaviour or the output. This has been manually tested with a 2.7 and 3.3.5 virtualenv.

There's a little bit of magic customisation going on here because, with an eye to testing, I'd like to be able to specify a test server in Travis to download a small amount of data rather than the full 7GiB on each commit :smile:.

This PR also lands the ability to customise which chunks are downloaded. This feature, for the moment, would break the server if used. It has been added with an eye to testing.

Aside: I may suggest a move to the [GDAL](http://www.gdal.org/) library to access the DEM TIFFs which has the advantage of being able to read the pixel-to-longitude/latitude transform directly from the TIFFs while preserving the use of mmap to avoid reading 7GiB into RAM. However, that's a discussion to have on another day.
