### PR TITLE
gitignore: add *.egg-info directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ uwsgi.yaml
 ruaumoko/dataset.c
 *.so
 build/
+*.egg-info


### PR DESCRIPTION
(This is pretty trivial :).)

Add the .egg-info directories which setuptools likes to sprinkle around
the source tree.
