### PR TITLE
remove duplication in requirements.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,4 @@
-# API
-Flask
-
-# Installation
+# Required for setup.py
 Cython
 
-# Core
-magicmemoryview
-
-# Downloader
-sh
-
-# Command-line option parsing
-docopt
+-e .

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,17 @@ setup(
     description='Ground Elevation API',
     long_description=long_description,
     install_requires=[
-        "docopt",
+        # Web API
         "Flask",
+
+        # Command line processing
+        "docopt",
+
+        # Core functionality
         "magicmemoryview",
-        "sh"
+
+        # Downloader
+        "sh",
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The requirements.txt file and setup.py's `install_requires` do serve
different purposes. I only recently got more of a handle on what those
purposes are. See [1] for a good overview.

A nice feature of pip discussed in [1] and which I was not aware of is
the ability to use a `-e .` idiom to add **ourselves** to the
requirements and thereby include the requirements listed in setup.py
while preserving the ability for requirements.txt to specify precise
library versions if required.

Using this idiom nicely reduces the duplication of dependency
information between requirements.txt and setup.py but retains the
ability to, for example, have Cython listed explicitly in
requirements.txt but only being an implicit dependency in setup.py.

The de-duplication also reduces the testing burden; we need only test
the `pip install -r requirements.txt` installation rather than testing
both requirements.txt and setup.py to catch missing any missing
dependencies.

[1] https://caremad.io/blog/setup-vs-requirement/
