### PR TITLE
add stub support for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ruaumoko/dataset.c
 *.so
 build/
 *.egg-info
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
     - "pip install -r requirements.txt"
 
 # Run tests
-script: "nosetests"
+script: "nosetests --with-coverage --cover-package=ruaumoko"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ python:
     - "3.3"
 
 install:
-    # Install (specific) requirements
+    # Install stuff for running test suite
+    - "pip install nose coverage"
+    # Install (specific) requirements and ourself
     - "pip install -r requirements.txt"
+
+# Run tests
+script: "nosetests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# Boilerplate to select python and add v2 and v3 to test matrix.
+language: python
+python:
+    - "2.7"
+    - "3.3"
+
+install:
+    # Install (specific) requirements
+    - "pip install -r requirements.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,4 @@
-# API
-Flask
-
-# Installation
+# Required for setup.py
 Cython
 
-# Core
-magicmemoryview
-
-# Downloader
-sh
-
-# Command-line option parsing
-docopt
+-e .

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,17 @@ setup(
     description='Ground Elevation API',
     long_description=long_description,
     install_requires=[
-        "docopt",
+        # Web API
         "Flask",
+
+        # Command line processing
+        "docopt",
+
+        # Core functionality
         "magicmemoryview",
-        "sh"
+
+        # Downloader
+        "sh",
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/testimport.py
+++ b/tests/testimport.py
@@ -1,0 +1,4 @@
+"""Test basic importing of the library."""
+
+def test_import():
+    import ruaumoko


### PR DESCRIPTION
> This PR should be merged **after** #15.

Add a very simple Travis-CI configuration which installs the software, any
requirements and then runs the test suite via nose. Adds a trivial test suite
which simply tries to `import ruaumoko`.
