### PR TITLE
use requests to download DEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ the [GNU GPL 3](http://gplv3.fsf.org/) (see LICENSE).
 ## Dependencies
 
 Python dependences may be found in `requirements.txt`. To run the downloader
-you will also require the `unzip` command (from the Debian package of the same
-name) and `convert` (from `imagemagick`).
+you will also require the `convert` command (from `imagemagick`).
 
 ## Dataset Format
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "magicmemoryview",
 
         # Downloader
-        "sh",
+        "sh", "requests",
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
It's a little brittle to shell out to `wget` to download the DEM data when
Python has the wonderful [requests](http://docs.python-requests.org/) library.
Make use of it for downloading the DEM.

A secondary benefit is that the library can be mocked in the test suite meaning
that we don't need to _actually_ have a full HTTP server stack up and running
in order to test the downloader.
