### PR TITLE
add tests for the web API

### DIFF
--- a/ruaumoko/api.py
+++ b/ruaumoko/api.py
@@ -31,7 +31,8 @@ def open_dataset():
     global elevation
 
     dir = app.config.get('ELEVATION_DIRECTORY', Dataset.default_location)
-    elevation = Dataset(dir)
+    res = app.config.get('ELEVATION_TILE_RESOLUTION', Dataset.default_res)
+    elevation = Dataset(dir, expected_res=res)
 
 
 @app.route('/<latitude>,<longitude>')

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ coverage
 
 # Mocking
 responses
+Flask-Testing

--- a/tests/testapi.py
+++ b/tests/testapi.py
@@ -1,0 +1,59 @@
+"""
+Test of Flask-based web API.
+"""
+import logging
+
+from flask.ext.testing import TestCase
+from ruaumoko.dataset import Dataset
+from ruaumoko.api import app
+
+from .util import MOCK_DATASET_PATH, MOCK_DATASET_TILE_SIZE
+
+LOG = logging.getLogger(__name__)
+
+class TestAPI(TestCase):
+    def create_app(self):
+        # Set app configuration
+        app.config['ELEVATION_DIRECTORY'] = MOCK_DATASET_PATH
+        app.config['ELEVATION_TILE_RESOLUTION'] = MOCK_DATASET_TILE_SIZE
+        return app
+
+    def test_root(self):
+        """Tests that the root route returns "not found"."""
+        self.assert404(self.client.get('/'))
+
+    def test_bad_lat_lng(self):
+        """Tests that we must pass in valid lat/longs."""
+        self.assert400(self.client.get('/a,b'))
+        self.assert400(self.client.get('/a,0'))
+        self.assert400(self.client.get('/0,b'))
+        self.assert400(self.client.get('/-100,0'))
+        self.assert400(self.client.get('/100,0'))
+        self.assert400(self.client.get('/52,-32'))
+        self.assert400(self.client.get('/52,374'))
+
+    def test_good_lat_lng(self):
+        """Tests that we can pass in good lat/longs and get results out which
+        match calls to Dataset.get().
+
+        """
+        # Load mock dataset
+        ds = Dataset(MOCK_DATASET_PATH, expected_res=MOCK_DATASET_TILE_SIZE)
+
+        # Function to compare a response for a lat/long with what we expect
+        def compare_request(lat, lng, resp):
+            self.assert200(resp)
+            body = resp.json
+            self.assertIsNotNone(body)
+            self.assertIn('elevation', body)
+            elevation = body['elevation']
+
+            # Compute "good" elevation
+            good_elev = ds.get(lat, lng)
+
+            self.assertAlmostEqual(good_elev, elevation)
+
+        # Kick off a load of requests and compare output
+        for lat in range(-85, 85, 5):
+            for lng in range(1, 359, 10):
+                compare_request(lat, lng, self.client.get('/{0},{1}'.format(lat,lng)))

--- a/tests/testasciimap.py
+++ b/tests/testasciimap.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from unittest import TestCase
 # NB: unittest.mock is part of the standard lib in later Pythons
 try:
     from unittest.mock import patch, call
@@ -8,9 +9,9 @@ except ImportError:
 
 from nose.tools import raises
 
-from .util import DownloadedDatasetTestCase
-
 import ruaumoko.asciiart as raa
+
+from .util import MOCK_DATASET_PATH
 
 expected_output_60_20 = [
     "                                                            ",
@@ -35,10 +36,10 @@ expected_output_60_20 = [
     "   .::-=++++++++-:....:.:-=++*####%%%%%%%%%%%%%%%%####***=. ",
 ]
 
-class TestASCIIMap(DownloadedDatasetTestCase):
+class TestASCIIMap(TestCase):
     def test_simple_output(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x10', MOCK_DATASET_PATH])
 
         # Patch sys.stdout.write
         stdout_write_patch = patch('sys.stdout.write')
@@ -62,63 +63,63 @@ class TestASCIIMap(DownloadedDatasetTestCase):
     @raises(ValueError)
     def test_incorrect_tile_size(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '30x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '30x10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_tile_size_negative(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x-10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x-10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_tile_size_non_int(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', 'twentyx10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', 'twentyx10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_tile_size_too_few(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_tile_size_too_many(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x10x1', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20', '--tile-shape', '20x10x1', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_output_size_negative(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x-20', '--tile-shape', '20x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x-20', '--tile-shape', '20x10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_output_size_non_int(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60xtwenty', '--tile-shape', '20x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60xtwenty', '--tile-shape', '20x10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_output_size_too_few(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60', '--tile-shape', '20x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60', '--tile-shape', '20x10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)
 
     def test_invalid_output_size_too_many(self):
         argv_patch = patch('sys.argv', [
-            'ruaumoko-ascii-map', '-s', '60x20x1', '--tile-shape', '20x10', self.dataset_path])
+            'ruaumoko-ascii-map', '-s', '60x20x1', '--tile-shape', '20x10', MOCK_DATASET_PATH])
         with argv_patch:
             rv = raa.main()
         self.assertNotEqual(rv, 0)

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -2,19 +2,20 @@ from tempfile import mkdtemp
 from shutil import rmtree
 import logging
 import os
+from unittest import TestCase
 
-from .util import DownloadedDatasetTestCase
+from .util import MOCK_DATASET_PATH
 
 from ruaumoko import Dataset
 
 LOG = logging.getLogger(__name__)
 
-class TestGet(DownloadedDatasetTestCase):
+class TestGet(TestCase):
     def test_dataset_was_downloaded(self):
         """Checks that a dataset was downloaded."""
-        assert os.path.isfile(self.dataset_path)
-        assert os.stat(self.dataset_path).st_size > 0
+        assert os.path.isfile(MOCK_DATASET_PATH)
+        assert os.stat(MOCK_DATASET_PATH).st_size > 0
 
     def test_create_dataset(self):
         """Check a dataset may be successfully opened."""
-        ds = Dataset(self.dataset_path, expected_res=(20,10))
+        ds = Dataset(MOCK_DATASET_PATH, expected_res=(20,10))

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,6 +12,10 @@ from ruaumoko._compat import urlunsplit
 LOG = logging.getLogger(__name__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'mock-data')
 
+# Path to the mock ruaumoko dataset and the tile-size within
+MOCK_DATASET_PATH = os.path.join(DATA_DIR, 'dem-dataset')
+MOCK_DATASET_TILE_SIZE = (20,10)
+
 class TemporaryDirectoryTestCase(TestCase):
     def setUp(self):
         super(TemporaryDirectoryTestCase, self).setUp()
@@ -40,15 +44,4 @@ def responses_add_dem_mocks(host='www.viewfinderpanoramas.org', path='DEM/TIF15'
         responses.add(responses.GET, file_url,
                 body=mock_zip.open(info).read(),
                 content_type='application/zip')
-
-class DownloadedDatasetTestCase(TemporaryDirectoryTestCase):
-    """A test case which also ensures that a downloaded dataset is available
-    before running each test. The dataset will be available at
-    self.dataset_path.
-
-    """
-    @responses.activate
-    def setUp(self):
-        super(DownloadedDatasetTestCase, self).setUp()
-        self.dataset_path = os.path.join(DATA_DIR, 'dem-dataset')
 


### PR DESCRIPTION
This PR closes the circle and allows all bits of ruaumoko to actually be
tested. Aside from a simple little test of the web API which compares it to
using Dataset directly, this also teaches the web application about the
different tile sizes used in production and testing.

After this PR, I _think_ that I'm almost done with ruaumoko and I can move on
to the predictor proper. :grin:

[Aside: the tile size thing is a little ugly and, in the fullness of time, some
sort of index/record of the tile sizes should probably be stored somewhere by
the downloader but that's not urgent. I'm loathe to change/add to the on-disk
representation since it would require a re-download on the actual ruaumoko
server.]
