### PR TITLE
README: add travis/coveralls badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ruaumoko: Elevation API for Tawhiri
 
+[![Build Status](https://travis-ci.org/cuspaceflight/ruaumoko.svg?branch=master)](https://travis-ci.org/cuspaceflight/ruaumoko)
+[![Coverage Status](https://coveralls.io/repos/cuspaceflight/ruaumoko/badge.png?branch=master)](https://coveralls.io/r/cuspaceflight/ruaumoko?branch=master)
+
 A Python module and web API for worldwide elevation data.
 
 This project is a part of the larger [Tawhiri Landing Predictor

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/cuspaceflight/ruaumoko.svg?branch=master)](https://travis-ci.org/cuspaceflight/ruaumoko)
 [![Coverage Status](https://coveralls.io/repos/cuspaceflight/ruaumoko/badge.png?branch=master)](https://coveralls.io/r/cuspaceflight/ruaumoko?branch=master)
+[![PyPI version](https://pypip.in/v/ruaumoko/badge.png)](https://pypi.python.org/pypi/Ruaumoko)
+[![PyPI downloads](https://pypip.in/d/ruaumoko/badge.png)](https://pypi.python.org/pypi/Ruaumoko)
 
 A Python module and web API for worldwide elevation data.
 


### PR DESCRIPTION
We're not a cool project unless we have these in our README.

We could also add in the PyPI badges (below) in as well if we want to go badge-tastic.

![](https://pypip.in/v/ruaumoko/badge.png)

![](https://pypip.in/d/ruaumoko/badge.png)
