### PR TITLE
make the development webserver useful for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ the [GNU GPL 3](http://gplv3.fsf.org/) (see LICENSE).
 Python dependences may be found in `requirements.txt`. To run the downloader
 you will also require the `convert` command (from `imagemagick`).
 
+## Running a development webserver
+
+The ``ruaumoko-api`` command can be used to run a development web server.
+
+```console
+$ ruaumoko-api runserver
+```
+
+This will use the default configuration. To use a custom configuration to, for
+example, change the dataset location use the ``RUAUMOKO_SETTINGS`` environment
+variable:
+
+```console
+$ cat > ruaumoko-development.txt <<EOL
+ELEVATION_DIRECTORY = '/path/to/your/dataset'
+EOL
+$ RUAUMOKO_SETTINGS=ruaumoko-development.txt ruaumoko-api runserver
+```
+
 ## Dataset Format
 
 Throughout Ruaumoko, data is indexed latitude-first/row-first

--- a/ruaumoko/api.py
+++ b/ruaumoko/api.py
@@ -44,17 +44,3 @@ def get_elevation(latitude, longitude):
         abort(400)
 
     return jsonify({"elevation": result})
-
-
-def main():
-    if sys.argv[1:] == ["--debug"]:
-        app.run(debug=True)
-    elif sys.argv[1:] == []:
-        app.run()
-    else:
-        print("Usage: {} [--debug]".format(sys.argv[0]), file=sys.stderr)
-        sys.exit(2)
-
-
-if __name__ == "__main__":
-    main()

--- a/ruaumoko/manager.py
+++ b/ruaumoko/manager.py
@@ -1,4 +1,5 @@
 """Command-line utility to run/manage webapp."""
+import os
 
 from flask.ext.script import Manager
 from .api import app
@@ -6,4 +7,6 @@ from .api import app
 manager = Manager(app)
 
 def main():
+    if 'RUAUMOKO_SETTINGS' in os.environ:
+        app.config.from_envvar('RUAUMOKO_SETTINGS')
     manager.run()

--- a/ruaumoko/manager.py
+++ b/ruaumoko/manager.py
@@ -1,0 +1,9 @@
+"""Command-line utility to run/manage webapp."""
+
+from flask.ext.script import Manager
+from .api import app
+
+manager = Manager(app)
+
+def main():
+    manager.run()

--- a/ruaumoko/manager.py
+++ b/ruaumoko/manager.py
@@ -1,3 +1,21 @@
+# Copyright 2014 (C) Rich Wareham <rich.cusf@richwareham.com>
+#
+# This file is part of Ruaumoko.
+# https://github.com/cuspaceflight/ruaumoko
+#
+# Ruaumoko is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ruaumoko is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ruaumoko. If not, see <http://www.gnu.org/licenses/>.
+#
 """Command-line utility to run/manage webapp."""
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def get_version():
     raise Exception("Could not find version number")
 
 console_scripts = [
-    "ruaumoko-api = ruaumoko.api:main",
+    "ruaumoko-api = ruaumoko.manager:main",
     "ruaumoko-get = ruaumoko.get_cmd:main",
     "ruaumoko-download = ruaumoko.download:main",
     "ruaumoko-ascii-map = ruaumoko.asciiart:main",
@@ -66,6 +66,7 @@ setup(
     install_requires=[
         # Web API
         "Flask",
+        "Flask-Script",
 
         # Command line processing
         "docopt",


### PR DESCRIPTION
On my machine, the ruaumoko dataset is not under `/srv`. This makes it rather
hard to run the web API. Modify the web api to a) use the more idiomatic
Flask-Script extension and b) allow configuration of dataset location or any
other configuration parameter via a config file.
